### PR TITLE
add iris and plane with ROS imu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
+
+project(uctf)
+
+find_package(gazebo REQUIRED)
+include_directories(${GAZEBO_INCLUDE_DIRS})
+link_directories(${GAZEBO_LIBRARY_DIRS})
+
+find_package(roscpp REQUIRED)
+include_directories(${roscpp_INCLUDE_DIRS})
+
+set(PROJECT_LIB_ROBOT_PLUGIN_NAME "RobotPlugin")
+
+include_directories(include)
+
+add_subdirectory(src)

--- a/launch/static.launch
+++ b/launch/static.launch
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch" pass_all_args="true">
+    <arg name="world_name" value="$(find uctf)/worlds/static.world" />
+  </include>
+</launch>

--- a/models/iris_with_ros_plugins/iris_with_ros_plugins.sdf
+++ b/models/iris_with_ros_plugins/iris_with_ros_plugins.sdf
@@ -1,0 +1,13 @@
+<sdf version="1.6">
+  <model name="iris_with_ros_plugins">
+    <include>
+      <uri>model://iris</uri>
+    </include>
+
+    <plugin name="ros_imu" filename='libgazebo_ros_imu.so'>
+      <bodyName>iris::iris/imu_link</bodyName>
+      <serviceName>iris/imu</serviceName>
+      <topicName>iris/imu</topicName>
+    </plugin>
+  </model>
+</sdf>

--- a/models/iris_with_ros_plugins/model.config
+++ b/models/iris_with_ros_plugins/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris</name>
+  <version>1.0</version>
+  <sdf version="1.4">iris_with_ros_plugins.sdf</sdf>
+
+  <author>
+   <name>Dirk Thomas</name>
+   <email>dthomas@osrfoundation.org</email>
+  </author>
+
+  <description>
+    This uses the existing model of the 3DR Iris Quadrotor from the
+    sitl_gazebo package and adds some Gazebo ROS plugins.
+  </description>
+</model>

--- a/models/plane_with_ros_plugins/model.config
+++ b/models/plane_with_ros_plugins/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>Plane</name>
+  <version>1.0</version>
+  <sdf version="1.4">plane_with_ros_plugins.sdf</sdf>
+
+  <author>
+   <name>Dirk Thomas</name>
+   <email>dthomas@osrfoundation.org</email>
+  </author>
+
+  <description>
+    This uses the existing model of a standard plane from the
+    sitl_gazebo package and adds some Gazebo ROS plugins.
+  </description>
+</model>

--- a/models/plane_with_ros_plugins/plane_with_ros_plugins.sdf
+++ b/models/plane_with_ros_plugins/plane_with_ros_plugins.sdf
@@ -1,0 +1,13 @@
+<sdf version="1.6">
+  <model name="plane_with_ros_plugins">
+    <include>
+      <uri>model://plane</uri>
+    </include>
+
+    <plugin name="ros_imu" filename='libgazebo_ros_imu.so'>
+      <bodyName>plane::plane/imu_link</bodyName>
+      <serviceName>plane/imu</serviceName>
+      <topicName>plane/imu</topicName>
+    </plugin>
+  </model>
+</sdf>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>uctf</name>
+  <version>0.0.0</version>
+  <description>Unmanned Capture The Flag.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/worlds/static.world
+++ b/worlds/static.world
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+
+    <physics name="default_physics" default="0" type="ode">
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+      <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    </physics>
+
+    <scene>
+      <shadows>false</shadows>
+      <sky>
+        <clouds/>
+      </sky>
+    </scene>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="grass">
+          <pose>0 0 0 0 0 0</pose>
+          <cast_shadows>false</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grass</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <include>
+      <uri>model://iris_with_ros_plugins</uri>
+    </include>
+
+    <include>
+      <uri>model://plane_with_ros_plugins</uri>
+    </include>
+  </world>
+</sdf>


### PR DESCRIPTION
To run the launch file you need to:
- build https://github.com/PX4/sitl_gazebo and set the Gazebo related environment variables (see their README)
- add the `models` and `worlds` folders of this package to the Gazebo environment variables
- add this package to the ROS_PACKAGE_PATH
