### PR TITLE
remove gazebo imu plugin for now

### DIFF
--- a/models/iris/iris.sdf
+++ b/models/iris/iris.sdf
@@ -446,11 +446,5 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-
-    <plugin name="ros_imu" filename='libgazebo_ros_imu.so'>
-      <bodyName>iris/imu_link</bodyName>
-      <serviceName>imu</serviceName>
-      <topicName>imu</topicName>
-    </plugin>
   </model>
 </sdf>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -419,11 +419,5 @@
       </elevator_joint>
     </plugin>
     <static>0</static>
-
-    <plugin name="ros_imu" filename='libgazebo_ros_imu.so'>
-      <bodyName>plane/imu_link</bodyName>
-      <serviceName>imu</serviceName>
-      <topicName>imu</topicName>
-    </plugin>
   </model>
 </sdf>


### PR DESCRIPTION
Since we now only use the topics bridged via mavlink we don't need this plugin anymore.
