### PR TITLE
most of the way to building inside docker

### DIFF
--- a/packaging/build_in_docker.bash
+++ b/packaging/build_in_docker.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+
+docker build -t sasc_build docker_build_env
+
+docker run -ti -v `pwd`:/tmp/packaging sasc_build bash -c 'cd /tmp/packaging && ./build_package.sh'

--- a/packaging/docker_build_env/Dockerfile
+++ b/packaging/docker_build_env/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get install -y python-rosinstall python-wstool
 RUN apt-get install -y libxslt1-dev libqwt-dev python-future libignition-transport-dev
 
 # from Ardupilot
-RUN apt-get install -y gawk make git arduino-core curl python-serial python-argparse openocd flex bison libncurses5-dev \
+RUN apt-get install -y gawk make git curl python-serial python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
           zip genromfs python-empy libc6-i386 g++ python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing ccache realpath

--- a/packaging/docker_build_env/Dockerfile
+++ b/packaging/docker_build_env/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+MAINTAINER Tully Foote<tfoote@osrfoundation.org>
+
+RUN apt-get update && echo TODO collapse me
+RUN apt-get install -y git equivs curl mercurial lsb-release
+
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 0xB01FA116
+
+RUN apt-get install -y python-rosinstall python-wstool
+
+
+RUN apt-get install -y libxslt1-dev libqwt-dev python-future libignition-transport-dev
+
+# from Ardupilot
+RUN apt-get install -y gawk make git arduino-core curl python-serial python-argparse openocd flex bison libncurses5-dev \
+          autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
+          zip genromfs python-empy libc6-i386 g++ python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing ccache realpath


### PR DESCRIPTION
Support for building in an isolated docker

This does not yet quite work. 

It does not have the ssh credentials for ssh defined submodules. That are open access but need a valid key to use the ssh interface to github. hopefully a .gitconfig rule can rewrite them?